### PR TITLE
Update brand colors to use purple design tokens

### DIFF
--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -53,7 +53,7 @@ const Header = () => {
             <Button
               variant="ghost"
               color="gray.600"
-              _hover={{ color: "brand.500" }}
+              _hover={{ color: "purple" }}
             >
               Ideas
             </Button>
@@ -62,7 +62,7 @@ const Header = () => {
             <Button
               variant="ghost"
               color="gray.600"
-              _hover={{ color: "brand.500" }}
+              _hover={{ color: "purple" }}
             >
               Submit
             </Button>
@@ -71,7 +71,7 @@ const Header = () => {
             <Button
               variant="ghost"
               color="gray.600"
-              _hover={{ color: "brand.500" }}
+              _hover={{ color: "purple" }}
             >
               Roadmap
             </Button>

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -85,7 +85,7 @@ const Header = () => {
                   <Avatar
                     size="sm"
                     name={user.name}
-                    bg="brand.500"
+                    bg="purple"
                     color="white"
                   />
                   <Text fontSize="sm" color="gray.700">

--- a/design-tokens.json
+++ b/design-tokens.json
@@ -1,0 +1,980 @@
+{
+  "color": {
+    "purple": {
+      "description": "",
+      "type": "color",
+      "value": "#ac7ef4ff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:536da10eb9bc5cf48d6b72b408baee3365415223,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "pink": {
+      "description": "",
+      "type": "color",
+      "value": "#eeb1caff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:84c1597f7ba4daac19b5bffdc8f9b1b9c35e2195,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "light blue": {
+      "description": "",
+      "type": "color",
+      "value": "#18b6f6ff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:63b609df2d088ec8be3f7da610a5152bff6458d4,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "dark blue": {
+      "description": "",
+      "type": "color",
+      "value": "#006ce9ff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:7b4b2dcdfb05c0e6dbe4cd59cff0fe2af1db3f26,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "orange": {
+      "description": "",
+      "type": "color",
+      "value": "#ef6c41ff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:ff043672d144eda2c2129a89e494166478d6ebac,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "yellow": {
+      "description": "",
+      "type": "color",
+      "value": "#f7c92eff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:2e389b5132c356d4e69ea16bbfb2c18255294da8,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "green": {
+      "description": "",
+      "type": "color",
+      "value": "#33b533ff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:f55ab2feb0c8cd03f0fbacc55c5dfe5594903d64,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "black": {
+      "description": "",
+      "type": "color",
+      "value": "#000000ff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:3844cf793bf025470df918c6d775d5763af55af0,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "white": {
+      "description": "",
+      "type": "color",
+      "value": "#ffffffff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:3b59d7e7b64bf4992b1c62abccf6814aa429325b,",
+          "exportKey": "color"
+        }
+      }
+    },
+    "dirty black": {
+      "description": "",
+      "type": "color",
+      "value": "#1d2023ff",
+      "blendMode": "normal",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:0d3c44040372dc05d31cc52a638739b8d78be78d,",
+          "exportKey": "color"
+        }
+      }
+    }
+  },
+  "grid": {
+    "builder desktop": {
+      "description": null,
+      "type": "custom-grid",
+      "value": {
+        "pattern": "columns",
+        "gutterSize": 25,
+        "alignment": "stretch",
+        "count": 12,
+        "offset": 95
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:36466b3ff7a795fe474b3744cb10119d3b5dcff1,",
+          "exportKey": "grid"
+        }
+      }
+    },
+    "builder mobile": {
+      "description": null,
+      "type": "custom-grid",
+      "value": {
+        "pattern": "columns",
+        "gutterSize": 20,
+        "alignment": "stretch",
+        "count": 4,
+        "offset": 35
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:18893893189dbf9808e9373aa04fff4c73f7c076,",
+          "exportKey": "grid"
+        }
+      }
+    }
+  },
+  "font": {
+    "h1 - 55pt bold poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 55,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 700,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -1.65,
+        "lineHeight": 66,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:688b336ddf139a29e5234bccb6dfcc1951d0dbc8,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "h2 - 40pt medium poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 40,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 500,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -1.2,
+        "lineHeight": 52,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:d27a8da295482143c5e63422fd33bbe86563cb7b,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "h3 - 32pt medium poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 32,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 500,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -0.96,
+        "lineHeight": 44,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:ad93c9f4eb119bb33b35d96110f4c4ca6aa7c98d,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "h4 - 24pt medium poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 24,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 500,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -0.24,
+        "lineHeight": 31.2,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:543dac9ceeb3f40d8e94b7b57841da9f40a7827b,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "paragraph - 16pt regular poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 16,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 400,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": 0,
+        "lineHeight": 27,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:a877b6cbc336f01c01e82cafb74757065cedf1f7,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "small paragraph - 14pt regular poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 14,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 400,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": 0,
+        "lineHeight": 19.6,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:2502a5a5a7c27f15a2b8a9faef34326fbc5f9c30,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "button - 16pt regular poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 16,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 500,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": 0,
+        "lineHeight": 24,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:2d6be6cf29a2a8dc409874d087247504ec8f2720,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "quote - 32pt medium poppins": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 32,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 500,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -0.96,
+        "lineHeight": 50,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:29389337dabe0341206f26a35eba848068077913,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "m_h1 - 35pt bold poppings": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 35,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 700,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -1.05,
+        "lineHeight": 45,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:4085a8f20b7aea31200e8fd8794280a001e3b56b,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "m_paragraph - 14pt regular": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 14,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 400,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": 0,
+        "lineHeight": 24,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:7c4cb57c79e9c0fe7fb42024146e75519fd6f2d5,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "m_h2 - 28pt medium poppings": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 28,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 500,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -0.84,
+        "lineHeight": 36,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:9f4959c6a703d8cbdc81b6b953b3cc974ec9c2e9,",
+          "exportKey": "font"
+        }
+      }
+    },
+    "m_quote - 25pt poppings regular": {
+      "type": "custom-fontStyle",
+      "value": {
+        "fontSize": 25,
+        "textDecoration": "none",
+        "fontFamily": "Poppins",
+        "fontWeight": 400,
+        "fontStyle": "normal",
+        "fontStretch": "normal",
+        "letterSpacing": -0.75,
+        "lineHeight": 41,
+        "paragraphIndent": 0,
+        "paragraphSpacing": 0,
+        "textCase": "none"
+      },
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "styleId": "S:653b7a7a26ef5d6d5de37fe8296faae63a0eca36,",
+          "exportKey": "font"
+        }
+      }
+    }
+  },
+  "typography": {
+    "h1 - 55pt bold poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 55
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 700
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -1.65
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 66
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "h2 - 40pt medium poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 40
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 500
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -1.2
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 52
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "h3 - 32pt medium poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 32
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 500
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -0.96
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 44
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "h4 - 24pt medium poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 24
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 500
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -0.24
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 31.2
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "paragraph - 16pt regular poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 16
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 400
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 27
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "small paragraph - 14pt regular poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 14
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 400
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 19.6
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "button - 16pt regular poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 16
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 500
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 24
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "quote - 32pt medium poppins": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 32
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 500
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -0.96
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 50
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "m_h1 - 35pt bold poppings": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 35
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 700
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -1.05
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 45
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "m_paragraph - 14pt regular": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 14
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 400
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 24
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "m_h2 - 28pt medium poppings": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 28
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 500
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -0.84
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 36
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    },
+    "m_quote - 25pt poppings regular": {
+      "fontSize": {
+        "type": "dimension",
+        "value": 25
+      },
+      "textDecoration": {
+        "type": "string",
+        "value": "none"
+      },
+      "fontFamily": {
+        "type": "string",
+        "value": "Poppins"
+      },
+      "fontWeight": {
+        "type": "number",
+        "value": 400
+      },
+      "fontStyle": {
+        "type": "string",
+        "value": "normal"
+      },
+      "fontStretch": {
+        "type": "string",
+        "value": "normal"
+      },
+      "letterSpacing": {
+        "type": "dimension",
+        "value": -0.75
+      },
+      "lineHeight": {
+        "type": "dimension",
+        "value": 41
+      },
+      "paragraphIndent": {
+        "type": "dimension",
+        "value": 0
+      },
+      "paragraphSpacing": {
+        "type": "dimension",
+        "value": 0
+      },
+      "textCase": {
+        "type": "string",
+        "value": "none"
+      }
+    }
+  }
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,16 +5,27 @@ import NextDocument, { Html, Head, Main, NextScript } from "next/document";
 import theme from "$/theme";
 
 export default class Document extends NextDocument {
-	render() {
-		return (
-			<Html lang="en">
-				<Head></Head>
-				<body>
-					<ColorModeScript initialColorMode={theme.config.initialColorMode} />
-					<Main />
-					<NextScript />
-				</body>
-			</Html>
-		);
-	}
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }

--- a/pages/ideas.tsx
+++ b/pages/ideas.tsx
@@ -261,7 +261,14 @@ const Ideas: NextPage = () => {
                         icon={<ChevronUpIcon />}
                         size="sm"
                         variant={idea.hasVoted ? "solid" : "outline"}
-                        colorScheme={idea.hasVoted ? "brand" : "gray"}
+                        bg={idea.hasVoted ? "purple" : "transparent"}
+                        color={idea.hasVoted ? "white" : "gray.600"}
+                        borderColor={idea.hasVoted ? "purple" : "gray.300"}
+                        _hover={{
+                          bg: idea.hasVoted ? "brand.600" : "purple",
+                          color: "white",
+                          borderColor: "purple",
+                        }}
                         onClick={() => handleVote(idea.id)}
                       />
                       <Text fontSize="sm" fontWeight="bold" color="gray.600">

--- a/pages/ideas.tsx
+++ b/pages/ideas.tsx
@@ -97,7 +97,7 @@ const mockIdeas: Idea[] = [
 
 const statusColors = {
   SUBMITTED: "gray",
-  PLANNED: "blue",
+  PLANNED: "lightBlue",
   IN_PROGRESS: "orange",
   COMPLETED: "green",
   REJECTED: "red",

--- a/pages/ideas.tsx
+++ b/pages/ideas.tsx
@@ -191,7 +191,7 @@ const Ideas: NextPage = () => {
             <Heading size="xl" mb={2} color="gray.900">
               Product Ideas & Feedback
             </Heading>
-            <Text color="gray.600" fontSize="lg">
+            <Text color="gray.600" size="lg">
               Help shape the future of Builder.io by voting on ideas and sharing
               your feedback
             </Text>

--- a/pages/ideas.tsx
+++ b/pages/ideas.tsx
@@ -294,7 +294,12 @@ const Ideas: NextPage = () => {
                       {/* Tags */}
                       <HStack spacing={2} mb={3}>
                         {idea.tags.map((tag) => (
-                          <Badge key={tag} variant="subtle" colorScheme="brand">
+                          <Badge
+                            key={tag}
+                            variant="subtle"
+                            bg="brand.100"
+                            color="purple"
+                          >
                             {tag}
                           </Badge>
                         ))}

--- a/pages/ideas.tsx
+++ b/pages/ideas.tsx
@@ -177,6 +177,7 @@ const Ideas: NextPage = () => {
       status: "success",
       duration: 2000,
       isClosable: true,
+      variant: "solid",
     });
   };
 

--- a/pages/ideas.tsx
+++ b/pages/ideas.tsx
@@ -177,19 +177,11 @@ const Ideas: NextPage = () => {
       status: "success",
       duration: 2000,
       isClosable: true,
-      position: "top",
-      render: () => (
-        <Box
-          bg="green.500"
-          color="white"
-          p={3}
-          borderRadius="md"
-          fontSize="sm"
-          fontWeight="bold"
-        >
-          Vote registered
-        </Box>
-      ),
+      variant: "solid",
+      containerStyle: {
+        backgroundColor: "#48BB78",
+        color: "white",
+      },
     });
   };
 

--- a/pages/ideas.tsx
+++ b/pages/ideas.tsx
@@ -177,7 +177,19 @@ const Ideas: NextPage = () => {
       status: "success",
       duration: 2000,
       isClosable: true,
-      variant: "solid",
+      position: "top",
+      render: () => (
+        <Box
+          bg="green.500"
+          color="white"
+          p={3}
+          borderRadius="md"
+          fontSize="sm"
+          fontWeight="bold"
+        >
+          Vote registered
+        </Box>
+      ),
     });
   };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,13 +87,13 @@ const Home: NextPage = () => {
                 <CardBody>
                   <VStack spacing={4} align="start">
                     <Box bg="brand.100" p={3} borderRadius="lg">
-                      <Icon as={StarIcon} color="brand.500" boxSize={6} />
+                      <Icon as={StarIcon} color="purple" boxSize={6} />
                     </Box>
                     <Box>
                       <Heading size="md" mb={2} color="gray.900">
                         Vote on Ideas
                       </Heading>
-                      <Text color="gray.600">
+                      <Text size="md" color="gray.600">
                         Help prioritize features by voting on ideas that matter
                         most to you and your team.
                       </Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,22 +34,10 @@ const Home: NextPage = () => {
           {/* Hero Section */}
           <VStack spacing={8} textAlign="center" py={8}>
             <Box>
-              <Heading
-                size="2xl"
-                color="gray.900"
-                mb={4}
-                fontWeight="800"
-                lineHeight="shorter"
-              >
+              <Heading size="2xl" color="gray.900" mb={4}>
                 Shape the Future of Builder.io
               </Heading>
-              <Text
-                fontSize="xl"
-                color="gray.600"
-                maxW="3xl"
-                mx="auto"
-                lineHeight="tall"
-              >
+              <Text size="lg" color="gray.600" maxW="3xl" mx="auto">
                 Your voice matters. Share ideas, vote on features, and help us
                 build the visual development platform that empowers your team.
               </Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -152,7 +152,7 @@ const Home: NextPage = () => {
               <Heading size="lg" mb={4} color="gray.900">
                 How It Works
               </Heading>
-              <Text fontSize="lg" color="gray.600" maxW="2xl" mx="auto">
+              <Text size="lg" color="gray.600" maxW="2xl" mx="auto">
                 Join the Builder.io community in shaping our platform
               </Text>
             </Box>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -165,7 +165,7 @@ const Home: NextPage = () => {
               <GridItem textAlign="center">
                 <VStack spacing={4}>
                   <Box
-                    bg="brand.500"
+                    bg="purple"
                     color="white"
                     borderRadius="full"
                     w={12}
@@ -182,7 +182,7 @@ const Home: NextPage = () => {
                     <Heading size="md" mb={2} color="gray.900">
                       Submit Ideas
                     </Heading>
-                    <Text color="gray.600">
+                    <Text size="md" color="gray.600">
                       Share your feature requests, improvements, or report
                       issues
                     </Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,12 +47,16 @@ const Home: NextPage = () => {
               <Link href="/ideas">
                 <Button
                   size="lg"
-                  colorScheme="brand"
+                  bg="purple"
+                  color="white"
                   rightIcon={<ArrowForwardIcon />}
                   px={8}
                   py={6}
-                  fontSize="lg"
-                  fontWeight="600"
+                  _hover={{
+                    bg: "brand.600",
+                    transform: "translateY(-1px)",
+                    boxShadow: "lg",
+                  }}
                 >
                   Browse Ideas
                 </Button>
@@ -61,11 +65,14 @@ const Home: NextPage = () => {
                 <Button
                   size="lg"
                   variant="outline"
-                  colorScheme="brand"
+                  borderColor="purple"
+                  color="purple"
                   px={8}
                   py={6}
-                  fontSize="lg"
-                  fontWeight="600"
+                  _hover={{
+                    bg: "brand.50",
+                    transform: "translateY(-1px)",
+                  }}
                 >
                   Submit Feedback
                 </Button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -129,13 +129,13 @@ const Home: NextPage = () => {
                 <CardBody>
                   <VStack spacing={4} align="start">
                     <Box bg="blue.100" p={3} borderRadius="lg">
-                      <Icon as={CalendarIcon} color="blue.500" boxSize={6} />
+                      <Icon as={CalendarIcon} color="lightBlue" boxSize={6} />
                     </Box>
                     <Box>
                       <Heading size="md" mb={2} color="gray.900">
                         Track Progress
                       </Heading>
-                      <Text color="gray.600">
+                      <Text size="md" color="gray.600">
                         Follow your ideas through our roadmap from submission to
                         completion.
                       </Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -256,7 +256,7 @@ const Home: NextPage = () => {
                   <Heading size="lg" mb={4} color="gray.900">
                     Ready to Get Started?
                   </Heading>
-                  <Text fontSize="lg" color="gray.600" maxW="2xl" mx="auto">
+                  <Text size="lg" color="gray.600" maxW="2xl" mx="auto">
                     Join hundreds of developers and designers who are helping
                     shape the future of visual development.
                   </Text>
@@ -266,11 +266,15 @@ const Home: NextPage = () => {
                   <Link href="/ideas">
                     <Button
                       size="lg"
-                      colorScheme="brand"
+                      bg="purple"
+                      color="white"
                       px={8}
                       py={6}
-                      fontSize="lg"
-                      fontWeight="600"
+                      _hover={{
+                        bg: "brand.600",
+                        transform: "translateY(-1px)",
+                        boxShadow: "lg",
+                      }}
                     >
                       Explore Ideas
                     </Button>
@@ -279,11 +283,14 @@ const Home: NextPage = () => {
                     <Button
                       size="lg"
                       variant="outline"
-                      colorScheme="brand"
+                      borderColor="purple"
+                      color="purple"
                       px={8}
                       py={6}
-                      fontSize="lg"
-                      fontWeight="600"
+                      _hover={{
+                        bg: "brand.50",
+                        transform: "translateY(-1px)",
+                      }}
                     >
                       View Roadmap
                     </Button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -193,7 +193,7 @@ const Home: NextPage = () => {
               <GridItem textAlign="center">
                 <VStack spacing={4}>
                   <Box
-                    bg="brand.500"
+                    bg="purple"
                     color="white"
                     borderRadius="full"
                     w={12}
@@ -210,7 +210,7 @@ const Home: NextPage = () => {
                     <Heading size="md" mb={2} color="gray.900">
                       Community Votes
                     </Heading>
-                    <Text color="gray.600">
+                    <Text size="md" color="gray.600">
                       The community votes on ideas to help us prioritize
                       development
                     </Text>
@@ -221,7 +221,7 @@ const Home: NextPage = () => {
               <GridItem textAlign="center">
                 <VStack spacing={4}>
                   <Box
-                    bg="brand.500"
+                    bg="purple"
                     color="white"
                     borderRadius="full"
                     w={12}
@@ -238,7 +238,7 @@ const Home: NextPage = () => {
                     <Heading size="md" mb={2} color="gray.900">
                       We Build It
                     </Heading>
-                    <Text color="gray.600">
+                    <Text size="md" color="gray.600">
                       Top-voted features get built and released to improve
                       Builder.io
                     </Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -108,13 +108,13 @@ const Home: NextPage = () => {
                 <CardBody>
                   <VStack spacing={4} align="start">
                     <Box bg="accent.100" p={3} borderRadius="lg">
-                      <Icon as={ChatIcon} color="accent.500" boxSize={6} />
+                      <Icon as={ChatIcon} color="yellow" boxSize={6} />
                     </Box>
                     <Box>
                       <Heading size="md" mb={2} color="gray.900">
                         Share Feedback
                       </Heading>
-                      <Text color="gray.600">
+                      <Text size="md" color="gray.600">
                         Submit feature requests, improvements, and bug reports
                         to help us build better tools.
                       </Text>

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -436,35 +436,51 @@ const Roadmap: NextPage = () => {
           <Card>
             <CardBody>
               <Grid
-                templateColumns="repeat(auto-fit, minmax(200px, 1fr))"
-                gap={6}
+                templateColumns="repeat(auto-fit, minmax(150px, 1fr))"
+                gap={4}
               >
                 <Box textAlign="center">
-                  <Text fontSize="2xl" fontWeight="bold" color="blue.500">
+                  <Text fontSize="2xl" fontWeight="bold" color="gray.500">
+                    {backlogItems.length}
+                  </Text>
+                  <Text color="gray.600" fontSize="sm">
+                    In Backlog
+                  </Text>
+                </Box>
+                <Box textAlign="center">
+                  <Text fontSize="2xl" fontWeight="bold" color="purple">
+                    {underReviewItems.length}
+                  </Text>
+                  <Text color="gray.600" fontSize="sm">
+                    Under Review
+                  </Text>
+                </Box>
+                <Box textAlign="center">
+                  <Text fontSize="2xl" fontWeight="bold" color="lightBlue">
                     {plannedItems.length}
                   </Text>
                   <Text color="gray.600" fontSize="sm">
-                    Features Planned
+                    Planned
                   </Text>
                 </Box>
                 <Box textAlign="center">
-                  <Text fontSize="2xl" fontWeight="bold" color="orange.500">
+                  <Text fontSize="2xl" fontWeight="bold" color="orange">
                     {inProgressItems.length}
                   </Text>
                   <Text color="gray.600" fontSize="sm">
-                    In Development
+                    In Progress
                   </Text>
                 </Box>
                 <Box textAlign="center">
-                  <Text fontSize="2xl" fontWeight="bold" color="green.500">
+                  <Text fontSize="2xl" fontWeight="bold" color="green">
                     {completedItems.length}
                   </Text>
                   <Text color="gray.600" fontSize="sm">
-                    Recently Shipped
+                    Completed
                   </Text>
                 </Box>
                 <Box textAlign="center">
-                  <Text fontSize="2xl" fontWeight="bold" color="brand.500">
+                  <Text fontSize="2xl" fontWeight="bold" color="purple">
                     {roadmapItems.reduce((sum, item) => sum + item.votes, 0)}
                   </Text>
                   <Text color="gray.600" fontSize="sm">

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -21,7 +21,7 @@ interface RoadmapItem {
   id: string;
   title: string;
   description: string;
-  status: "PLANNED" | "IN_PROGRESS" | "COMPLETED";
+  status: "BACKLOG" | "UNDER_REVIEW" | "PLANNED" | "IN_PROGRESS" | "COMPLETED";
   tags: string[];
   votes: number;
   comments: number;

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -142,7 +142,7 @@ const roadmapItems: RoadmapItem[] = [
 
   // IN_PROGRESS
   {
-    id: "4",
+    id: "11",
     title: "Dark Mode for Dashboard",
     description:
       "System-wide dark mode theme for the Builder.io dashboard and visual editor.",
@@ -154,7 +154,7 @@ const roadmapItems: RoadmapItem[] = [
     quarter: "Q1 2024",
   },
   {
-    id: "5",
+    id: "12",
     title: "Real-time Collaboration",
     description:
       "Multiple users can edit the same content simultaneously with live cursors and conflict resolution.",
@@ -166,7 +166,7 @@ const roadmapItems: RoadmapItem[] = [
     quarter: "Q1 2024",
   },
   {
-    id: "6",
+    id: "13",
     title: "Enhanced TypeScript Support",
     description:
       "Better TypeScript intellisense, error handling, and type safety in the visual editor.",
@@ -177,10 +177,22 @@ const roadmapItems: RoadmapItem[] = [
     progress: 60,
     quarter: "Q1 2024",
   },
+  {
+    id: "14",
+    title: "Advanced Form Builder",
+    description:
+      "Drag-and-drop form builder with conditional logic, validation rules, and submission handling.",
+    status: "IN_PROGRESS",
+    tags: ["forms", "builder", "validation"],
+    votes: 178,
+    comments: 32,
+    progress: 25,
+    quarter: "Q2 2024",
+  },
 
   // COMPLETED
   {
-    id: "7",
+    id: "15",
     title: "Figma Plugin 2.0",
     description:
       "Complete redesign of the Figma plugin with improved sync, better component mapping, and batch operations.",
@@ -191,7 +203,7 @@ const roadmapItems: RoadmapItem[] = [
     quarter: "Q4 2023",
   },
   {
-    id: "8",
+    id: "16",
     title: "Webhook Management Dashboard",
     description:
       "Visual interface for managing webhooks with testing, logs, and retry mechanisms.",
@@ -202,7 +214,7 @@ const roadmapItems: RoadmapItem[] = [
     quarter: "Q4 2023",
   },
   {
-    id: "9",
+    id: "17",
     title: "Performance Analytics",
     description:
       "Detailed performance metrics for published content including Core Web Vitals tracking.",
@@ -211,6 +223,28 @@ const roadmapItems: RoadmapItem[] = [
     votes: 178,
     comments: 41,
     quarter: "Q4 2023",
+  },
+  {
+    id: "18",
+    title: "Content Scheduling System",
+    description:
+      "Schedule content publication and updates with timezone support and automated workflows.",
+    status: "COMPLETED",
+    tags: ["scheduling", "automation", "cms"],
+    votes: 145,
+    comments: 29,
+    quarter: "Q4 2023",
+  },
+  {
+    id: "19",
+    title: "Enhanced Media Library",
+    description:
+      "Improved media management with AI-powered tagging, bulk operations, and CDN optimization.",
+    status: "COMPLETED",
+    tags: ["media", "ai", "cdn"],
+    votes: 123,
+    comments: 24,
+    quarter: "Q3 2023",
   },
 ];
 

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -403,6 +403,10 @@ const RoadmapColumn = ({
 };
 
 const Roadmap: NextPage = () => {
+  const backlogItems = roadmapItems.filter((item) => item.status === "BACKLOG");
+  const underReviewItems = roadmapItems.filter(
+    (item) => item.status === "UNDER_REVIEW",
+  );
   const plannedItems = roadmapItems.filter((item) => item.status === "PLANNED");
   const inProgressItems = roadmapItems.filter(
     (item) => item.status === "IN_PROGRESS",

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -249,6 +249,16 @@ const roadmapItems: RoadmapItem[] = [
 ];
 
 const statusConfig = {
+  BACKLOG: {
+    title: "Backlog",
+    color: "gray",
+    description: "Ideas under consideration",
+  },
+  UNDER_REVIEW: {
+    title: "Under Review",
+    color: "purple",
+    description: "Ideas being evaluated",
+  },
   PLANNED: {
     title: "Planned",
     color: "blue",

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -492,21 +492,38 @@ const Roadmap: NextPage = () => {
           </Card>
 
           {/* Kanban Board */}
-          <Grid
-            templateColumns={["1fr", "1fr", "repeat(3, 1fr)"]}
-            gap={6}
-            alignItems="start"
-          >
-            <GridItem>
-              <RoadmapColumn status="PLANNED" items={plannedItems} />
-            </GridItem>
-            <GridItem>
-              <RoadmapColumn status="IN_PROGRESS" items={inProgressItems} />
-            </GridItem>
-            <GridItem>
-              <RoadmapColumn status="COMPLETED" items={completedItems} />
-            </GridItem>
-          </Grid>
+          <Box>
+            <Text color="gray.600" fontSize="sm" mb={4}>
+              Scroll horizontally to see all stages →
+            </Text>
+            <Box overflowX="auto" pb={4}>
+              <HStack
+                spacing={6}
+                alignItems="start"
+                minW="max-content"
+                w="max-content"
+              >
+                <Box minW="300px" maxW="300px">
+                  <RoadmapColumn status="BACKLOG" items={backlogItems} />
+                </Box>
+                <Box minW="300px" maxW="300px">
+                  <RoadmapColumn
+                    status="UNDER_REVIEW"
+                    items={underReviewItems}
+                  />
+                </Box>
+                <Box minW="300px" maxW="300px">
+                  <RoadmapColumn status="PLANNED" items={plannedItems} />
+                </Box>
+                <Box minW="300px" maxW="300px">
+                  <RoadmapColumn status="IN_PROGRESS" items={inProgressItems} />
+                </Box>
+                <Box minW="300px" maxW="300px">
+                  <RoadmapColumn status="COMPLETED" items={completedItems} />
+                </Box>
+              </HStack>
+            </Box>
+          </Box>
 
           {/* Footer Note */}
           <Card bg="blue.50" borderColor="blue.200">

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -353,7 +353,8 @@ const RoadmapColumn = ({
                       <Badge
                         key={tag}
                         variant="subtle"
-                        colorScheme="brand"
+                        bg="brand.100"
+                        color="purple"
                         fontSize="xs"
                       >
                         {tag}

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -31,9 +31,83 @@ interface RoadmapItem {
 
 // Mock roadmap data
 const roadmapItems: RoadmapItem[] = [
-  // PLANNED
+  // BACKLOG
   {
     id: "1",
+    title: "AI-Powered Content Suggestions",
+    description:
+      "Intelligent content recommendations based on user behavior and performance analytics.",
+    status: "BACKLOG",
+    tags: ["ai", "content", "analytics"],
+    votes: 45,
+    comments: 8,
+  },
+  {
+    id: "2",
+    title: "Advanced SEO Optimization Tools",
+    description:
+      "Built-in SEO analysis with recommendations for meta tags, structured data, and performance.",
+    status: "BACKLOG",
+    tags: ["seo", "optimization", "analytics"],
+    votes: 67,
+    comments: 12,
+  },
+  {
+    id: "3",
+    title: "Voice Interface for Content Creation",
+    description:
+      "Voice commands for hands-free content editing and navigation through the builder interface.",
+    status: "BACKLOG",
+    tags: ["voice", "accessibility", "editor"],
+    votes: 23,
+    comments: 4,
+  },
+  {
+    id: "4",
+    title: "Advanced Security Dashboard",
+    description:
+      "Comprehensive security monitoring with audit logs, access controls, and threat detection.",
+    status: "BACKLOG",
+    tags: ["security", "monitoring", "compliance"],
+    votes: 89,
+    comments: 16,
+  },
+
+  // UNDER_REVIEW
+  {
+    id: "5",
+    title: "GraphQL API Enhancement",
+    description:
+      "Extended GraphQL API with real-time subscriptions and advanced filtering capabilities.",
+    status: "UNDER_REVIEW",
+    tags: ["api", "graphql", "realtime"],
+    votes: 134,
+    comments: 28,
+  },
+  {
+    id: "6",
+    title: "Multi-Brand Content Management",
+    description:
+      "Support for managing multiple brands with separate themes, assets, and content libraries.",
+    status: "UNDER_REVIEW",
+    tags: ["multi-tenant", "branding", "cms"],
+    votes: 156,
+    comments: 34,
+  },
+  {
+    id: "7",
+    title: "Advanced Component Library",
+    description:
+      "Expanded component library with advanced layout options and interactive elements.",
+    status: "UNDER_REVIEW",
+    tags: ["components", "library", "editor"],
+    votes: 98,
+    comments: 21,
+  },
+
+  // PLANNED
+  {
+    id: "8",
     title: "Advanced A/B Testing Suite",
     description:
       "Comprehensive A/B testing framework with statistical significance tracking and advanced targeting rules.",
@@ -44,7 +118,7 @@ const roadmapItems: RoadmapItem[] = [
     quarter: "Q2 2024",
   },
   {
-    id: "2",
+    id: "9",
     title: "Mobile App Content Management",
     description:
       "Native mobile app for content creators to manage and publish content on the go.",
@@ -55,7 +129,7 @@ const roadmapItems: RoadmapItem[] = [
     quarter: "Q3 2024",
   },
   {
-    id: "3",
+    id: "10",
     title: "Enhanced Localization Tools",
     description:
       "Better translation workflow with context-aware suggestions and collaboration features.",

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -67,7 +67,10 @@ const theme = extendTheme({
   components: {
     Button: {
       baseStyle: {
-        fontWeight: "600",
+        fontFamily: "Poppins",
+        fontSize: "16px", // Button typography from design tokens
+        lineHeight: "24px",
+        fontWeight: "500",
         borderRadius: "lg",
       },
       variants: {

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -103,18 +103,60 @@ const theme = extendTheme({
     },
     Heading: {
       baseStyle: {
+        fontFamily: "Poppins",
         fontWeight: "700",
         color: "gray.900",
       },
       sizes: {
+        "2xl": {
+          fontSize: ["35px", "55px"], // Mobile H1 / Desktop H1 from design tokens
+          lineHeight: ["45px", "66px"],
+          letterSpacing: ["-1.05px", "-1.65px"],
+        },
         xl: {
-          fontSize: ["2.5rem", "3rem", "3.5rem"],
+          fontSize: ["28px", "40px"], // Mobile H2 / Desktop H2 from design tokens
+          lineHeight: ["36px", "52px"],
+          letterSpacing: ["-0.84px", "-1.2px"],
+          fontWeight: "500",
         },
         lg: {
-          fontSize: ["1.75rem", "2rem", "2.25rem"],
+          fontSize: "32px", // H3 from design tokens
+          lineHeight: "44px",
+          letterSpacing: "-0.96px",
+          fontWeight: "500",
         },
         md: {
-          fontSize: ["1.25rem", "1.375rem", "1.5rem"],
+          fontSize: "24px", // H4 from design tokens
+          lineHeight: "31.2px",
+          letterSpacing: "-0.24px",
+          fontWeight: "500",
+        },
+      },
+    },
+    Text: {
+      baseStyle: {
+        fontFamily: "Poppins",
+      },
+      sizes: {
+        lg: {
+          fontSize: "16px", // Paragraph from design tokens
+          lineHeight: "27px",
+          fontWeight: "400",
+        },
+        md: {
+          fontSize: "16px", // Paragraph from design tokens
+          lineHeight: "27px",
+          fontWeight: "400",
+        },
+        sm: {
+          fontSize: "14px", // Small paragraph from design tokens
+          lineHeight: "19.6px",
+          fontWeight: "400",
+        },
+        xs: {
+          fontSize: "14px", // Mobile paragraph from design tokens
+          lineHeight: "24px",
+          fontWeight: "400",
         },
       },
     },

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -10,33 +10,46 @@ const theme = extendTheme({
   config,
   fonts: {
     heading:
-      "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
-    body: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
+      "Poppins, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
+    body: "Poppins, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
   },
   colors: {
+    // Design token colors
+    purple: "#ac7ef4",
+    pink: "#eeb1ca",
+    lightBlue: "#18b6f6",
+    darkBlue: "#006ce9",
+    orange: "#ef6c41",
+    yellow: "#f7c92e",
+    green: "#33b533",
+    black: "#000000",
+    white: "#ffffff",
+    dirtyBlack: "#1d2023",
+
+    // Updated brand colors using design tokens
     brand: {
-      50: "#f5f1ff",
-      100: "#ede4ff",
-      200: "#dcc9ff",
-      300: "#c8a8ff",
-      400: "#b087ff",
-      500: "#8247E5", // Builder purple
-      600: "#7338d1",
-      700: "#632bb8",
-      800: "#52249a",
-      900: "#451f7e",
+      50: "#f3f0fd",
+      100: "#e8e1fb",
+      200: "#d6c7f7",
+      300: "#bfa1f1",
+      400: "#ac7ef4", // From design tokens - purple
+      500: "#9963e8",
+      600: "#8649d4",
+      700: "#7138b8",
+      800: "#5d2f96",
+      900: "#4d2979",
     },
     accent: {
-      50: "#fffbeb",
-      100: "#fef3c7",
-      200: "#fde68a",
-      300: "#fcd34d",
-      400: "#fbbf24",
-      500: "#f59e0b", // Soft yellow accent
-      600: "#d97706",
-      700: "#b45309",
-      800: "#92400e",
-      900: "#78350f",
+      50: "#fefbf0",
+      100: "#fef5dc",
+      200: "#fde9b4",
+      300: "#fcdb81",
+      400: "#f7c92e", // From design tokens - yellow
+      500: "#f4b91a",
+      600: "#d99c0f",
+      700: "#b47b0f",
+      800: "#925f14",
+      900: "#784f16",
     },
     gray: {
       50: "#fafafa",
@@ -48,7 +61,7 @@ const theme = extendTheme({
       600: "#525252",
       700: "#404040",
       800: "#262626",
-      900: "#171717",
+      900: "#1d2023", // From design tokens - dirty black
     },
   },
   components: {


### PR DESCRIPTION
This pull request updates the color scheme throughout the application to use purple-based design tokens instead of the previous brand colors.

Changes made:
- Updated header button hover colors from "brand.500" to "purple"
- Changed avatar background color from "brand.500" to "purple"
- Added new design-tokens.json file with color, grid, and font definitions
- Updated roadmap badge colors to use new purple color scheme
- Modified roadmap statistics colors to use design token colors (lightBlue, orange, green, purple)
- Added new roadmap columns for BACKLOG and UNDER_REVIEW statuses
- Updated theme.ts to use Poppins font family and new color palette based on design tokens
- Replaced brand color palette with purple-based colors (#ac7ef4 as primary)
- Added new color definitions (purple, pink, lightBlue, darkBlue, orange, yellow, green)
- Updated typography styles to match design token specifications
- Enhanced button, heading, and text component styles with Poppins font and proper sizing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9004d085ad7844229b39145ff5fb818a/flare-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9004d085ad7844229b39145ff5fb818a</projectId>-->
<!--<branchName>flare-hub</branchName>-->